### PR TITLE
fix: Improve research agent execution and report generation

### DIFF
--- a/research.py
+++ b/research.py
@@ -1000,7 +1000,13 @@ Remember to start by creating a detailed TODO plan using write_todos before begi
 
                     # Collect messages from all nodes for the final result
                     if "messages" in node_data:
-                        result["messages"].extend(node_data["messages"])
+                        messages = node_data["messages"]
+                        # Handle Overwrite objects from deepagents
+                        if hasattr(messages, "value"):
+                            messages = messages.value
+                        # Only extend if it's actually a list
+                        if isinstance(messages, list):
+                            result["messages"].extend(messages)
 
                     # Check for TODO updates
                     if "todos" in node_data:
@@ -1016,7 +1022,13 @@ Remember to start by creating a detailed TODO plan using write_todos before begi
                     if node_name == "model":
                         # Model is thinking
                         if "messages" in node_data:
-                            for msg in node_data["messages"]:
+                            msgs = node_data["messages"]
+                            # Handle Overwrite objects from deepagents
+                            if hasattr(msgs, "value"):
+                                msgs = msgs.value
+                            if not isinstance(msgs, list):
+                                continue
+                            for msg in msgs:
                                 if hasattr(msg, "content") and msg.content:
                                     # Check if it's a tool call
                                     if hasattr(msg, "tool_calls") and msg.tool_calls:


### PR DESCRIPTION
## Summary

- Fix duplicate agent execution after streaming (agent was running twice)
- Use FilesystemBackend to write reports to actual disk (not in-memory)
- Add explicit instructions to exclude todos from report content
- Require mandatory inline citations in reports
- Handle Overwrite objects from deepagents streaming
- Improve emergency report message filtering

## Changes

1. **Remove duplicate agent execution** - Agent was being executed twice (once via stream(), once via invoke()). Now we collect results during streaming.

2. **FilesystemBackend** - The deepagents library defaults to StateBackend (in-memory), which meant write_file calls didn't write to disk. Now using FilesystemBackend.

3. **Report content rules** - Added explicit instructions that reports should never include TODO lists, internal planning, or JSON structures.

4. **Inline citations** - Every paragraph with researched info must have [1], [2] style citations.

5. **Overwrite handling** - deepagents sometimes returns Overwrite objects instead of lists; now handled properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)