### PR TITLE
fix: Remove TOC from PDF export so title appears first

### DIFF
--- a/export_pdf.py
+++ b/export_pdf.py
@@ -132,8 +132,6 @@ def convert_with_pandoc(md_file: str, pdf_path: str) -> tuple[bool, str]:
             "fontsize=11pt",
             "-V",
             "documentclass=article",
-            "--toc",
-            "--toc-depth=2",
             "-V",
             "colorlinks=true",
             "-V",


### PR DESCRIPTION
## Summary

Remove table of contents (TOC) from PDF export so the document title appears at the top of the first page.

## Problem

The TOC was appearing before the document title, pushing the actual content down.

## Solution

Remove `--toc` and `--toc-depth` options from the pandoc command.

## Test plan

- [x] PDF generated successfully
- [x] Title now appears at top of first page

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)