### PR TITLE
feat: Add CLI argument support for non-interactive research

### DIFF
--- a/run_research.sh
+++ b/run_research.sh
@@ -6,6 +6,10 @@
 #   ./run_research.sh "Your research question here"
 #   ./run_research.sh  # Will prompt for question
 #
+# Options (via environment variables):
+#   ITERATIONS=300 ./run_research.sh "question"  # Custom iterations
+#   PROVIDER=tavily ./run_research.sh "question" # Use Tavily provider
+#
 
 set -e
 
@@ -30,21 +34,21 @@ if [ -z "$QUESTION" ]; then
     exit 1
 fi
 
+# Configuration with defaults
+ITERATIONS="${ITERATIONS:-200}"
+PROVIDER="${PROVIDER:-auto}"
+
 echo ""
 echo "=========================================="
 echo "Starting Deep Research"
 echo "=========================================="
 echo "Question: $QUESTION"
+echo "Iterations: $ITERATIONS"
+echo "Provider: $PROVIDER"
 echo ""
 
-# Run research with deep mode, auto provider selection
-# Using heredoc to provide answers to prompts
-python research.py << EOF
-$QUESTION
-deep
-auto
-200
-EOF
+# Run research with CLI arguments (non-interactive mode)
+python research.py --deep --iterations "$ITERATIONS" --provider "$PROVIDER" "$QUESTION"
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
## Summary

Add command-line argument support to `research.py` for non-interactive/scripted usage.

## New CLI Usage

```bash
python research.py "question"              # Quick mode
python research.py -d "question"           # Deep mode  
python research.py -d -i 300 "question"    # Deep mode with 300 iterations
python research.py -p tavily "question"    # Use Tavily provider
python research.py                         # Interactive mode (unchanged)
```

## Shell Script

Updated `run_research.sh` to use CLI arguments:
```bash
./run_research.sh "Your question"
ITERATIONS=300 ./run_research.sh "Your question"
```

## Test plan

- [x] All 13 tests pass
- [x] `python research.py --help` works
- [x] Interactive mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)