### PR TITLE
fix: PDF bronnen als klikbare links

### DIFF
--- a/research.py
+++ b/research.py
@@ -742,10 +742,11 @@ How to cite inline:
 How to format the Sources section:
 - End with ## Bronnen (or ## Sources in English reports)
 - Number sources sequentially: [1], [2], [3], etc.
-- Format each source as: [number] Title - URL
+- Format each source as a markdown link: [number] [Title](URL)
+- Put each source on its own line for readability
 - Example:
-  [1] LangGraph Documentation - https://langchain.com/langgraph
-  [2] CrewAI GitHub - https://github.com/crewai/crewai
+  [1] [LangGraph Documentation](https://langchain.com/langgraph)
+  [2] [CrewAI GitHub](https://github.com/crewai/crewai)
 
 CRITICAL REQUIREMENTS:
 - EVERY paragraph that contains researched information must have at least one citation


### PR DESCRIPTION
## Summary

- Wijzig de instructies voor het formatteren van de bronnen-sectie van `[1] Title - URL` naar `[1] [Title](URL)` (markdown link syntax)
- Voeg instructie toe om elke bron op een eigen regel te zetten voor betere leesbaarheid
- Pandoc converteert nu de bronnen correct naar klikbare hyperlinks in de PDF

## Test plan

- [ ] Nieuwe research uitvoeren en controleren of bronnen correct geformatteerd zijn in markdown
- [ ] PDF exporteren en controleren of links klikbaar zijn

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)