### PR TITLE
feat: Live search status panel met laatste 5 zoekresultaten

### DIFF
--- a/test_report_guarantee.py
+++ b/test_report_guarantee.py
@@ -402,6 +402,38 @@ def test_refine_emergency_report_with_llm_handles_exception():
         assert result is None
 
 
+def test_search_status_display_add_search():
+    """Test that SearchStatusDisplay correctly tracks searches"""
+    from research import SearchStatusDisplay
+
+    display = SearchStatusDisplay(max_history=3)
+
+    # Add searches
+    display.add_search(1, "test query 1", 10, "TestProvider", False)
+    display.add_search(2, "test query 2", 5, "TestProvider", True)
+
+    assert len(display.recent_searches) == 2
+    assert display.recent_searches[0]["num"] == 1
+    assert display.recent_searches[1]["cached"] is True
+
+
+def test_search_status_display_max_history():
+    """Test that SearchStatusDisplay respects max_history limit"""
+    from research import SearchStatusDisplay
+
+    display = SearchStatusDisplay(max_history=2)
+
+    # Add more than max_history searches
+    display.add_search(1, "query 1", 10, "Provider", False)
+    display.add_search(2, "query 2", 10, "Provider", False)
+    display.add_search(3, "query 3", 10, "Provider", False)
+
+    # Should only keep last 2
+    assert len(display.recent_searches) == 2
+    assert display.recent_searches[0]["num"] == 2
+    assert display.recent_searches[1]["num"] == 3
+
+
 if __name__ == "__main__":
     print("Running report guarantee tests...")
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implementeert een live-updating status panel dat de terminal overzichtelijk houdt tijdens research:

- Nieuwe `SearchStatusDisplay` klasse voor het tracken van zoekactiviteit
- Gecombineerde status panel toont zowel zoekresultaten als taken
- Live panel vervangt scrollende console output
- Panel toont laatste 5 zoekopdrachten met query, resultaten en provider
- Panel updatet automatisch bij elke nieuwe zoekopdracht

## Probleem

De terminal liep vol met zoekresultaten tijdens research (165+ resultaten), wat het moeilijk maakte om te zien wat de agent aan het doen was.

## Oplossing

Een live updating block met de laatste 5 zoekresultaten:
```
╭─────────────────── 🔍 Zoekactiviteit (laatste 5) ───────────────────╮
│ #  1 Dutch egalitarian culture power distance...  → 10 (DuckDuckGo) │
│ #  2 Rotterdam Erasmus University AI research...  → 10 (DuckDuckGo) │
│ #  3 "22.7%" Dutch businesses AI adoption...      → 10 (DuckDuckGo) │
│ #  4 Kickstart AI Netherlands public private...   → 10 (DuckDuckGo) │
│ #  5 AI agent leadership transformations...       → 10 (DuckDuckGo) │
╰────────────────────────────────────────────────────────────────────╯
```

## Test plan

- [x] 2 nieuwe tests voor `SearchStatusDisplay`
- [x] Alle 21 tests slagen

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)