### PR TITLE
feat: Add LLM cost tracking to research agent

### DIFF
--- a/tests/test_prompt_changes.py
+++ b/tests/test_prompt_changes.py
@@ -53,7 +53,10 @@ def test_prompts():
     else:
         print("✓ FORBIDDEN AGENT STATEMENTS gevonden")
 
-    if "Now I'll compile" in research_instructions or "Now I will" not in research_instructions:
+    if (
+        "Now I'll compile" in research_instructions
+        or "Now I will" not in research_instructions
+    ):
         # Check dat het in de verboden lijst staat
         if '"Now I\'ll compile..."' not in research_instructions:
             errors.append("❌ Ontbreekt: 'Now I'll compile' in verboden lijst")
@@ -61,7 +64,10 @@ def test_prompts():
             print("✓ Agent statements in verboden lijst")
 
     # Test 4: Sub-research prompt
-    if "RAW FINDINGS" not in sub_research_prompt.upper() and "raw research findings" not in sub_research_prompt:
+    if (
+        "RAW FINDINGS" not in sub_research_prompt.upper()
+        and "raw research findings" not in sub_research_prompt
+    ):
         errors.append("❌ Sub-research prompt: ontbreekt 'raw findings' instructie")
     else:
         print("✓ Sub-research prompt: raw findings instructie aanwezig")
@@ -162,7 +168,7 @@ def scan_report(filepath: str):
 
     # Statistieken
     word_count = len(content.split())
-    print(f"\nStatistieken:")
+    print("\nStatistieken:")
     print(f"  - Woorden: {word_count:,}")
     print(f"  - Karakters: {len(content):,}")
     print(f"  - Regels: {total_lines}")
@@ -191,7 +197,9 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         report_ok = scan_report(sys.argv[1])
     else:
-        print("\nTip: python test_prompt_changes.py <rapport.md> om een rapport te scannen")
+        print(
+            "\nTip: python test_prompt_changes.py <rapport.md> om een rapport te scannen"
+        )
         report_ok = True
 
     # Exit code


### PR DESCRIPTION
## Summary

Implementeert issue #31 - voegt LLM kosten tracking toe aan de research agent.

- **Pricing configuratie**: `ANTHROPIC_PRICING` dict met kosten per model ($3/1M input, $15/1M output voor Sonnet)
- **Cost berekening**: `calculate_cost()` functie voor USD kosten
- **Token tracking**: `AgentTracker` uitgebreid met `add_token_usage()`, `get_total_cost()`, `reset_token_tracking()`
- **Deep research**: Trackt tokens van main agent en sub-agents via `usage_metadata`
- **Quick research**: Trackt tokens van directe LLM calls
- **Statistieken**: Toont tokens en geschatte kosten in eindstatistieken

### Voorbeeld output
```
📊 Tokens gebruikt  125,432 (in: 98,234, out: 27,198)
💰 Geschatte kosten $0.7025
```

## Test plan

- [x] `pytest tests/` - 71 tests passen (11 nieuwe voor cost tracking)
- [x] `ruff check` en `ruff format` - geen errors
- [ ] Handmatig testen met echte research run

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)