### PR TITLE
feat: Add custom templates and web interface

### DIFF
--- a/ai_researcher/prompts/deep_research.txt
+++ b/ai_researcher/prompts/deep_research.txt
@@ -153,6 +153,8 @@ only flowing prose. Highlight the most important insights.]
 
 [The rest of the report with well-structured sections]
 
+{{TEMPLATE_SECTIONS}}
+
 ## Sources / Bronnen
 
 [Numbered source list with markdown links]

--- a/ai_researcher/prompts/deep_research.txt
+++ b/ai_researcher/prompts/deep_research.txt
@@ -102,14 +102,27 @@ Only edit the file once at a time (if you call this tool in parallel, there may 
 
 REMINDER: Before you finish your work, you MUST have created research/final_report.md. Do not mark your work as complete until this file exists!
 
-COMPLETION CHECKLIST - VERIFY BEFORE STOPPING:
-Before you consider your work complete, verify ALL of these:
-1. ✓ Did you actually call write_file to create research/final_report.md?
-2. ✓ Does the file contain a complete report (not just a plan or notes)?
-3. ✓ Is the report in the correct language (same as the question)?
+⚠️ COMPLETION CHECKLIST - MANDATORY VERIFICATION ⚠️
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Before you mark any task as "completed" or stop working, you MUST:
+
+1. CHECK: Does research/final_report.md physically exist?
+   - If NO → Call write_file to create it IMMEDIATELY
+   - If YES → Verify it contains actual content (not empty)
+
+2. The "Finalize report" task is NEVER complete until the file exists!
+   - Do NOT mark it completed based on "planning to write"
+   - Do NOT mark it completed based on "I will write next"
+   - ONLY mark it completed AFTER calling write_file successfully
+
+3. YOUR WORK IS NOT DONE until write_file has been called with the complete report.
+
+COMMON MISTAKE TO AVOID:
+❌ WRONG: Marking "Finalize report" as completed → then stopping
+✅ RIGHT: Call write_file with report content → THEN mark as completed
 
 If you haven't written the report yet, DO NOT STOP. Call write_file NOW!
-The emergency fallback system will create a low-quality report if you fail to do this.
+The emergency fallback system will create a low-quality report if you fail to do this - this is considered a FAILURE.
 
 ITERATION AWARENESS:
 The system monitors your iteration usage. If you receive an URGENT message about approaching the iteration limit:

--- a/ai_researcher/runners/deep.py
+++ b/ai_researcher/runners/deep.py
@@ -159,11 +159,13 @@ _critique_sub_agent = {
 }
 
 # Create the global agent with FilesystemBackend (default template)
+# Use virtual_mode=True so paths like "/research/final_report.md" are resolved
+# relative to cwd, not as absolute filesystem paths
 _agent = create_deep_agent(
     tools=[_internet_search],
     system_prompt=research_instructions,
     subagents=[_critique_sub_agent, _research_sub_agent],
-    backend=FilesystemBackend(),
+    backend=FilesystemBackend(virtual_mode=True),
 )
 
 
@@ -180,11 +182,12 @@ def _create_agent_with_template(template_name: str, language: str = "en"):
     )
 
     # Create a new agent with the customized prompt
+    # Use virtual_mode=True so paths are resolved relative to cwd
     return create_deep_agent(
         tools=[_internet_search],
         system_prompt=customized_instructions,
         subagents=[_critique_sub_agent, _research_sub_agent],
-        backend=FilesystemBackend(),
+        backend=FilesystemBackend(virtual_mode=True),
     )
 
 

--- a/ai_researcher/runners/deep.py
+++ b/ai_researcher/runners/deep.py
@@ -1,6 +1,7 @@
 """Deep research mode - agentic research with sub-agents."""
 
 import os
+import random
 import time
 from typing import Literal
 
@@ -57,8 +58,20 @@ def get_dynamic_status(tool_name: str | None, tracker) -> str:
                 if active_form:
                     return f"⏳ {active_form}"
 
-    # Default thinking status
-    return "🤔 Agent analyseert..."
+    # Rotating default thinking statuses for visual feedback
+    thinking_statuses = [
+        "🤔 Agent analyseert...",
+        "💭 Informatie verwerken...",
+        "🧠 Aan het nadenken...",
+        "📚 Bronnen evalueren...",
+        "🔬 Gegevens onderzoeken...",
+        "✨ Inzichten verzamelen...",
+        "🎯 Strategie bepalen...",
+        "📊 Data analyseren...",
+        "🔗 Verbanden leggen...",
+        "💡 Conclusies vormen...",
+    ]
+    return random.choice(thinking_statuses)
 
 
 # Load prompts

--- a/ai_researcher/search/tools.py
+++ b/ai_researcher/search/tools.py
@@ -7,7 +7,6 @@ from rich.table import Table
 from tavily import TavilyClient
 from multi_search_api import SmartSearchTool
 
-from ..config import suppress_output
 from ..ui.console import console
 
 
@@ -27,6 +26,7 @@ class HybridSearchTool:
                 serper_api_key=os.getenv("SERPER_API_KEY"),
                 brave_api_key=os.getenv("BRAVE_API_KEY"),
                 enable_cache=True,  # Thread-safe since multi-search-api v0.1.1
+                quiet=True,  # Suppress all logging output for clean UI
             )
 
     def normalize_multi_search_response(self, response):
@@ -56,10 +56,7 @@ class HybridSearchTool:
             return result
 
         elif self.provider == "multi-search":
-            with suppress_output():
-                response = self.multi_search.search(
-                    query=query, num_results=max_results
-                )
+            response = self.multi_search.search(query=query, num_results=max_results)
             normalized = self.normalize_multi_search_response(response)
             provider_name = normalized.get("_provider", "Unknown")
             self.provider_usage[provider_name] = (
@@ -71,10 +68,9 @@ class HybridSearchTool:
         elif self.provider == "auto":
             # Try multi-search first (free), fallback to Tavily
             try:
-                with suppress_output():
-                    response = self.multi_search.search(
-                        query=query, num_results=max_results
-                    )
+                response = self.multi_search.search(
+                    query=query, num_results=max_results
+                )
                 normalized = self.normalize_multi_search_response(response)
                 provider_name = normalized.get("_provider", "Unknown")
                 self.provider_usage[provider_name] = (

--- a/ai_researcher/templates/__init__.py
+++ b/ai_researcher/templates/__init__.py
@@ -1,0 +1,17 @@
+"""Research report templates module."""
+
+from .loader import (
+    load_template,
+    list_templates,
+    get_template_prompt,
+    get_template_info,
+    TemplateNotFoundError,
+)
+
+__all__ = [
+    "load_template",
+    "list_templates",
+    "get_template_prompt",
+    "get_template_info",
+    "TemplateNotFoundError",
+]

--- a/ai_researcher/templates/comparison.yaml
+++ b/ai_researcher/templates/comparison.yaml
@@ -1,0 +1,40 @@
+name: comparison
+description: Compare two or more options, products, or technologies
+description_nl: Vergelijk twee of meer opties, producten of technologieën
+
+sections:
+  - title: "Overview of Options / Overzicht Opties"
+    title_nl: "Overzicht van de Opties"
+    title_en: "Overview of Options"
+    prompt: "Provide a brief introduction to each option being compared. Include key characteristics and background."
+    prompt_nl: "Geef een korte introductie van elke optie die wordt vergeleken. Vermeld de belangrijkste kenmerken en achtergrond."
+
+  - title: "Comparison Criteria / Vergelijkingscriteria"
+    title_nl: "Vergelijkingscriteria"
+    title_en: "Comparison Criteria"
+    prompt: "Define the criteria used for comparison. Explain why these criteria are relevant for the decision."
+    prompt_nl: "Definieer de criteria die voor de vergelijking worden gebruikt. Leg uit waarom deze criteria relevant zijn voor de beslissing."
+
+  - title: "Comparison Table / Vergelijkingstabel"
+    title_nl: "Vergelijkingstabel"
+    title_en: "Comparison Table"
+    prompt: "Create a structured comparison table with all options and criteria. Use clear ratings or assessments per criterion."
+    prompt_nl: "Maak een gestructureerde vergelijkingstabel met alle opties en criteria. Gebruik duidelijke beoordelingen per criterium."
+
+  - title: "Detailed Analysis / Gedetailleerde Analyse"
+    title_nl: "Gedetailleerde Analyse"
+    title_en: "Detailed Analysis"
+    prompt: "Analyze each criterion in depth. Discuss the trade-offs and nuances for each option."
+    prompt_nl: "Analyseer elk criterium grondig. Bespreek de afwegingen en nuances voor elke optie."
+
+  - title: "Recommendation / Aanbeveling"
+    title_nl: "Aanbeveling"
+    title_en: "Recommendation"
+    prompt: "Provide a clear, substantiated recommendation. Explain which option is best for which use case or context."
+    prompt_nl: "Geef een duidelijke, onderbouwde aanbeveling. Leg uit welke optie het beste is voor welke use case of context."
+
+notes: |
+  Comparison template for evaluating multiple options. The comparison table
+  should use a consistent format (e.g., ratings, checkmarks, or qualitative
+  assessments). The recommendation should consider different scenarios where
+  each option might be preferred.

--- a/ai_researcher/templates/default.yaml
+++ b/ai_researcher/templates/default.yaml
@@ -1,0 +1,12 @@
+name: default
+description: Standard research report with executive summary and flexible sections
+description_nl: Standaard onderzoeksrapport met management samenvatting en flexibele secties
+
+# Default template uses the standard report structure from deep_research.txt
+# No mandatory sections - the agent determines the best structure based on the question
+sections: []
+
+notes: |
+  This is the default template. The report structure will be determined
+  automatically based on the research question. The agent will choose
+  appropriate sections for the specific topic.

--- a/ai_researcher/templates/loader.py
+++ b/ai_researcher/templates/loader.py
@@ -1,0 +1,146 @@
+"""Template loader for research report templates."""
+
+from pathlib import Path
+
+import yaml
+
+
+class TemplateNotFoundError(Exception):
+    """Raised when a template cannot be found."""
+
+    pass
+
+
+# Directory containing template YAML files
+TEMPLATES_DIR = Path(__file__).parent
+
+
+def load_template(name: str) -> dict:
+    """
+    Load a template by name.
+
+    Args:
+        name: Template name (without .yaml extension)
+
+    Returns:
+        Dictionary with template configuration
+
+    Raises:
+        TemplateNotFoundError: If template doesn't exist
+    """
+    template_path = TEMPLATES_DIR / f"{name}.yaml"
+
+    if not template_path.exists():
+        available = list_templates()
+        raise TemplateNotFoundError(
+            f"Template '{name}' not found. Available templates: {', '.join(available)}"
+        )
+
+    with open(template_path, "r", encoding="utf-8") as f:
+        template = yaml.safe_load(f)
+
+    # Validate required fields
+    if not template.get("name"):
+        template["name"] = name
+    if not template.get("sections"):
+        template["sections"] = []
+
+    return template
+
+
+def list_templates() -> list[str]:
+    """
+    List all available template names.
+
+    Returns:
+        List of template names (without .yaml extension)
+    """
+    templates = []
+    for file in TEMPLATES_DIR.glob("*.yaml"):
+        templates.append(file.stem)
+    return sorted(templates)
+
+
+def get_template_info() -> list[dict]:
+    """
+    Get information about all available templates.
+
+    Returns:
+        List of dicts with 'name' and 'description' for each template
+    """
+    info = []
+    for name in list_templates():
+        try:
+            template = load_template(name)
+            info.append(
+                {
+                    "name": template.get("name", name),
+                    "description": template.get("description", "No description"),
+                }
+            )
+        except Exception:
+            info.append({"name": name, "description": "Error loading template"})
+    return info
+
+
+def get_template_prompt(template: dict, language: str = "en") -> str:
+    """
+    Generate prompt section from template.
+
+    Args:
+        template: Template dictionary (from load_template)
+        language: Language code ('en' or 'nl')
+
+    Returns:
+        String with formatted section instructions for the prompt
+    """
+    sections = template.get("sections", [])
+    if not sections:
+        return ""
+
+    # Language-specific labels
+    if language == "nl":
+        header = "VERPLICHTE RAPPORT STRUCTUUR (volg dit template exact):"
+        section_label = "Sectie"
+        focus_label = "Focus"
+    else:
+        header = "MANDATORY REPORT STRUCTURE (follow this template exactly):"
+        section_label = "Section"
+        focus_label = "Focus"
+
+    lines = [header, ""]
+
+    for i, section in enumerate(sections, 1):
+        title = section.get("title", f"{section_label} {i}")
+        prompt = section.get("prompt", "")
+
+        lines.append(f"## {title}")
+        if prompt:
+            lines.append(f"{focus_label}: {prompt}")
+        lines.append("")
+
+    # Add template-specific notes if present
+    notes = template.get("notes")
+    if notes:
+        lines.append(notes)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def get_default_template() -> dict:
+    """
+    Get the default template.
+
+    Returns:
+        Default template dictionary, or minimal template if not found
+    """
+    try:
+        return load_template("default")
+    except TemplateNotFoundError:
+        # Return minimal template if default.yaml doesn't exist
+        return {
+            "name": "default",
+            "description": "Standard research report",
+            "sections": [],
+        }

--- a/ai_researcher/templates/market.yaml
+++ b/ai_researcher/templates/market.yaml
@@ -1,0 +1,45 @@
+name: market
+description: Market analysis with trends, competitors, and opportunities
+description_nl: Marktanalyse met trends, concurrenten en kansen
+
+sections:
+  - title: "Market Overview / Marktoverzicht"
+    title_nl: "Marktoverzicht"
+    title_en: "Market Overview"
+    prompt: "Provide an overview of the market including size, growth rate, and key segments. Include relevant statistics and data."
+    prompt_nl: "Geef een overzicht van de markt inclusief omvang, groeipercentage en belangrijkste segmenten. Vermeld relevante statistieken en data."
+
+  - title: "Market Trends / Markttrends"
+    title_nl: "Markttrends"
+    title_en: "Market Trends"
+    prompt: "Identify and analyze current market trends. What developments are shaping the market? What emerging patterns are visible?"
+    prompt_nl: "Identificeer en analyseer huidige markttrends. Welke ontwikkelingen bepalen de markt? Welke opkomende patronen zijn zichtbaar?"
+
+  - title: "Competitive Landscape / Concurrentielandschap"
+    title_nl: "Concurrentielandschap"
+    title_en: "Competitive Landscape"
+    prompt: "Analyze the key players in the market. Include market shares, positioning, and competitive advantages of major competitors."
+    prompt_nl: "Analyseer de belangrijkste spelers in de markt. Vermeld marktaandelen, positionering en concurrentievoordelen van grote concurrenten."
+
+  - title: "Target Audience / Doelgroep"
+    title_nl: "Doelgroep"
+    title_en: "Target Audience"
+    prompt: "Define and analyze the target audience. What are their needs, behaviors, and preferences?"
+    prompt_nl: "Definieer en analyseer de doelgroep. Wat zijn hun behoeften, gedrag en voorkeuren?"
+
+  - title: "Opportunities and Challenges / Kansen en Uitdagingen"
+    title_nl: "Kansen en Uitdagingen"
+    title_en: "Opportunities and Challenges"
+    prompt: "Identify market opportunities and potential challenges. What gaps exist? What barriers to entry are present?"
+    prompt_nl: "Identificeer marktkansen en mogelijke uitdagingen. Welke hiaten zijn er? Welke toetredingsbarrières zijn aanwezig?"
+
+  - title: "Strategic Implications / Strategische Implicaties"
+    title_nl: "Strategische Implicaties"
+    title_en: "Strategic Implications"
+    prompt: "Provide strategic recommendations based on the market analysis. How can opportunities be captured? How can challenges be addressed?"
+    prompt_nl: "Geef strategische aanbevelingen op basis van de marktanalyse. Hoe kunnen kansen worden benut? Hoe kunnen uitdagingen worden aangepakt?"
+
+notes: |
+  Market analysis template for business intelligence. Include quantitative
+  data where available (market size, growth rates, market shares). Use
+  frameworks like Porter's Five Forces where applicable.

--- a/ai_researcher/templates/swot.yaml
+++ b/ai_researcher/templates/swot.yaml
@@ -1,0 +1,39 @@
+name: swot
+description: SWOT Analysis (Strengths, Weaknesses, Opportunities, Threats)
+description_nl: SWOT Analyse (Sterktes, Zwaktes, Kansen, Bedreigingen)
+
+sections:
+  - title: "Strengths / Sterktes"
+    title_nl: "Sterktes"
+    title_en: "Strengths"
+    prompt: "Identify the internal strengths and advantages. What works well? What are the key capabilities and resources?"
+    prompt_nl: "Identificeer de interne sterktes en voordelen. Wat werkt goed? Wat zijn de belangrijkste capaciteiten en middelen?"
+
+  - title: "Weaknesses / Zwaktes"
+    title_nl: "Zwaktes"
+    title_en: "Weaknesses"
+    prompt: "Identify the internal weaknesses and limitations. What could be improved? What are the gaps or challenges?"
+    prompt_nl: "Identificeer de interne zwaktes en beperkingen. Wat kan verbeterd worden? Wat zijn de hiaten of uitdagingen?"
+
+  - title: "Opportunities / Kansen"
+    title_nl: "Kansen"
+    title_en: "Opportunities"
+    prompt: "Identify external opportunities. What trends or changes could be leveraged? What new possibilities exist?"
+    prompt_nl: "Identificeer externe kansen. Welke trends of veranderingen kunnen benut worden? Welke nieuwe mogelijkheden zijn er?"
+
+  - title: "Threats / Bedreigingen"
+    title_nl: "Bedreigingen"
+    title_en: "Threats"
+    prompt: "Identify external threats and risks. What obstacles exist? What could negatively impact success?"
+    prompt_nl: "Identificeer externe bedreigingen en risico's. Welke obstakels zijn er? Wat kan succes negatief beïnvloeden?"
+
+  - title: "Strategic Recommendations / Strategische Aanbevelingen"
+    title_nl: "Strategische Aanbevelingen"
+    title_en: "Strategic Recommendations"
+    prompt: "Provide actionable recommendations based on the SWOT analysis. How to leverage strengths and opportunities while addressing weaknesses and threats?"
+    prompt_nl: "Geef concrete aanbevelingen op basis van de SWOT-analyse. Hoe sterktes en kansen benutten en zwaktes en bedreigingen aanpakken?"
+
+notes: |
+  SWOT analysis template for strategic evaluation. Each section should contain
+  substantive analysis with specific examples and evidence from research.
+  The recommendations should directly connect to the SWOT findings.

--- a/ai_researcher/tracking/agent_tracker.py
+++ b/ai_researcher/tracking/agent_tracker.py
@@ -27,7 +27,7 @@ class AgentTracker:
         self.model_name = "claude-sonnet-4-5-20250929"
         # Session timing and status
         self.start_time: float | None = None
-        self.current_status: str = "Initialiseren..."
+        self.current_status: str = "⏳ Initialiseren..."
         # Callback for web interface updates
         self.on_update: callable | None = None
 
@@ -72,7 +72,7 @@ class AgentTracker:
     def start_session(self):
         """Start timing for a research session."""
         self.start_time = time.time()
-        self.current_status = "Onderzoek starten..."
+        self.current_status = "🚀 Onderzoek starten..."
 
     def get_elapsed_time(self) -> str:
         """Return formatted elapsed time string."""

--- a/ai_researcher/tracking/agent_tracker.py
+++ b/ai_researcher/tracking/agent_tracker.py
@@ -28,6 +28,30 @@ class AgentTracker:
         # Session timing and status
         self.start_time: float | None = None
         self.current_status: str = "Initialiseren..."
+        # Callback for web interface updates
+        self.on_update: callable | None = None
+
+    def notify_update(self, update_type: str = "status"):
+        """Notify listeners about state changes."""
+        if self.on_update is not None:
+            try:
+                self.on_update(update_type, self.to_dict())
+            except Exception:
+                pass  # Don't let callback errors break the main flow
+
+    def to_dict(self) -> dict:
+        """Convert tracker state to dictionary for serialization."""
+        return {
+            "iteration_count": self.iteration_count,
+            "recursion_limit": self.recursion_limit,
+            "searches_count": self.searches_count,
+            "cache_hits": self.cache_hits,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "current_status": self.current_status,
+            "current_todos": self.current_todos,
+            "elapsed": self.get_elapsed_time(),
+        }
 
     def add_token_usage(self, input_tokens: int, output_tokens: int):
         """Add token usage from an API call."""

--- a/ai_researcher/ui/display.py
+++ b/ai_researcher/ui/display.py
@@ -1,7 +1,7 @@
 """Display functions for updating the live UI."""
 
 from .console import console
-from .panels import create_todo_panel, create_combined_status_panel
+from .panels import create_todo_panel
 
 
 def display_todos(tracker, search_display, todos):
@@ -9,24 +9,22 @@ def display_todos(tracker, search_display, todos):
     # Store todos for combined display
     tracker.current_todos = todos
 
-    # If Live display is active, update it with combined panel
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(search_display, tracker, todos)
-        tracker.live_display.update(combined)
-    else:
-        # Fallback: print todo panel normally
+    # Notify callback for web interface
+    tracker.notify_update("todos")
+
+    # If no Live display, print panel normally (fallback)
+    if tracker.live_display is None:
         panel = create_todo_panel(todos)
         if panel:
             console.print(panel)
+    # Note: Live display auto-refreshes via LiveStatusRenderable
 
 
 def update_search_display(tracker, search_display):
     """Update the live display with current search status."""
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(
-            search_display, tracker, tracker.current_todos
-        )
-        tracker.live_display.update(combined)
+    # Notify callback for web interface
+    tracker.notify_update("search")
+    # Note: Live display auto-refreshes via LiveStatusRenderable
 
 
 def update_agent_status(tracker, search_display):
@@ -35,8 +33,6 @@ def update_agent_status(tracker, search_display):
     This function is called frequently during agent execution to show
     real-time progress even when no searches are happening.
     """
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(
-            search_display, tracker, tracker.current_todos
-        )
-        tracker.live_display.update(combined)
+    # Notify callback for web interface
+    tracker.notify_update("status")
+    # Note: Live display auto-refreshes via LiveStatusRenderable

--- a/ai_researcher/ui/display.py
+++ b/ai_researcher/ui/display.py
@@ -1,7 +1,7 @@
 """Display functions for updating the live UI."""
 
 from .console import console
-from .panels import create_todo_panel
+from .panels import create_todo_panel, create_combined_status_panel
 
 
 def display_todos(tracker, search_display, todos):
@@ -12,19 +12,28 @@ def display_todos(tracker, search_display, todos):
     # Notify callback for web interface
     tracker.notify_update("todos")
 
-    # If no Live display, print panel normally (fallback)
-    if tracker.live_display is None:
+    # Update Live display with new content
+    if tracker.live_display is not None:
+        combined = create_combined_status_panel(search_display, tracker, todos)
+        tracker.live_display.update(combined)
+    else:
+        # Fallback: print todo panel normally
         panel = create_todo_panel(todos)
         if panel:
             console.print(panel)
-    # Note: Live display auto-refreshes via LiveStatusRenderable
 
 
 def update_search_display(tracker, search_display):
     """Update the live display with current search status."""
     # Notify callback for web interface
     tracker.notify_update("search")
-    # Note: Live display auto-refreshes via LiveStatusRenderable
+
+    # Update Live display with new content
+    if tracker.live_display is not None:
+        combined = create_combined_status_panel(
+            search_display, tracker, tracker.current_todos
+        )
+        tracker.live_display.update(combined)
 
 
 def update_agent_status(tracker, search_display):
@@ -35,4 +44,10 @@ def update_agent_status(tracker, search_display):
     """
     # Notify callback for web interface
     tracker.notify_update("status")
-    # Note: Live display auto-refreshes via LiveStatusRenderable
+
+    # Update Live display with new content
+    if tracker.live_display is not None:
+        combined = create_combined_status_panel(
+            search_display, tracker, tracker.current_todos
+        )
+        tracker.live_display.update(combined)

--- a/ai_researcher/ui/display.py
+++ b/ai_researcher/ui/display.py
@@ -1,53 +1,50 @@
-"""Display functions for updating the live UI."""
+"""Display functions for updating the live UI.
+
+The Live display uses LiveStatusRenderable which auto-refreshes via
+refresh_per_second=4. We do NOT call live_display.update() because that
+would replace the LiveStatusRenderable with a static Group, breaking
+the auto-refresh behavior.
+
+Instead, these functions just update the underlying data (tracker, search_display)
+and the LiveStatusRenderable picks up the changes on its next automatic refresh.
+"""
 
 from .console import console
-from .panels import create_todo_panel, create_combined_status_panel
+from .panels import create_todo_panel
 
 
 def display_todos(tracker, search_display, todos):
-    """Display TODO list - uses in-place update if Live is active."""
-    # Store todos for combined display
+    """Display TODO list - updates data for Live display auto-refresh."""
+    # Store todos for combined display - LiveStatusRenderable will pick this up
     tracker.current_todos = todos
 
     # Notify callback for web interface
     tracker.notify_update("todos")
 
-    # Update Live display with new content
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(search_display, tracker, todos)
-        tracker.live_display.update(combined)
-    else:
-        # Fallback: print todo panel normally
+    # If Live is not active, fall back to direct printing
+    if tracker.live_display is None:
         panel = create_todo_panel(todos)
         if panel:
             console.print(panel)
+    # Note: No update() call - LiveStatusRenderable auto-refreshes
 
 
 def update_search_display(tracker, search_display):
-    """Update the live display with current search status."""
+    """Update search status - data is auto-refreshed by LiveStatusRenderable."""
     # Notify callback for web interface
     tracker.notify_update("search")
-
-    # Update Live display with new content
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(
-            search_display, tracker, tracker.current_todos
-        )
-        tracker.live_display.update(combined)
+    # Note: No update() call - LiveStatusRenderable auto-refreshes
+    # search_display.recent_searches is already updated by the caller
 
 
 def update_agent_status(tracker, search_display):
-    """Update the live display with current agent status.
+    """Update agent status - data is auto-refreshed by LiveStatusRenderable.
 
-    This function is called frequently during agent execution to show
-    real-time progress even when no searches are happening.
+    This function is called frequently during agent execution. The tracker's
+    current_status is updated by the caller before this function is called.
+    The LiveStatusRenderable picks up all data changes on its next refresh.
     """
     # Notify callback for web interface
     tracker.notify_update("status")
-
-    # Update Live display with new content
-    if tracker.live_display is not None:
-        combined = create_combined_status_panel(
-            search_display, tracker, tracker.current_todos
-        )
-        tracker.live_display.update(combined)
+    # Note: No update() call - LiveStatusRenderable auto-refreshes
+    # tracker.current_status is already updated by the caller

--- a/ai_researcher/web/__init__.py
+++ b/ai_researcher/web/__init__.py
@@ -1,0 +1,5 @@
+"""Web interface module for AI Researcher."""
+
+from .app import create_app, run_server
+
+__all__ = ["create_app", "run_server"]

--- a/ai_researcher/web/app.py
+++ b/ai_researcher/web/app.py
@@ -1,0 +1,65 @@
+"""FastAPI application for AI Researcher web interface."""
+
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from .routes import router
+from .state import research_state
+
+
+# Get the directory containing this file
+WEB_DIR = Path(__file__).parent
+TEMPLATES_DIR = WEB_DIR / "templates"
+STATIC_DIR = WEB_DIR / "static"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage application lifespan."""
+    # Startup
+    yield
+    # Shutdown - cleanup any running research
+    research_state.cleanup()
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(
+        title="AI Research Agent",
+        description="Web interface for the AI Research Agent",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    # Mount static files
+    if STATIC_DIR.exists():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+    # Include routes
+    app.include_router(router)
+
+    # Store templates in app state for access in routes
+    app.state.templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+    return app
+
+
+def run_server(host: str = "127.0.0.1", port: int = 8000, reload: bool = False):
+    """Run the web server."""
+    import uvicorn
+
+    uvicorn.run(
+        "ai_researcher.web.app:create_app",
+        host=host,
+        port=port,
+        reload=reload,
+        factory=True,
+    )
+
+
+# Create app instance for uvicorn
+app = create_app()

--- a/ai_researcher/web/routes.py
+++ b/ai_researcher/web/routes.py
@@ -1,0 +1,281 @@
+"""FastAPI routes for AI Researcher web interface."""
+
+import asyncio
+import os
+from datetime import datetime
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from pydantic import BaseModel
+
+from ..templates import get_template_info
+from ..config import RESEARCH_FOLDER
+from .state import research_state, ResearchSession, ResearchStatus
+from .sse import format_sse_event
+
+
+router = APIRouter()
+
+
+class StartResearchRequest(BaseModel):
+    """Request body for starting research."""
+
+    question: str
+    template: str | None = None
+    recursion_limit: int = 200
+
+
+@router.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    """Render the home page."""
+    templates = request.app.state.templates
+    template_list = get_template_info()
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "templates": template_list,
+        },
+    )
+
+
+@router.post("/research/start")
+async def start_research(
+    request: Request, body: StartResearchRequest, background_tasks: BackgroundTasks
+):
+    """Start a new research session."""
+    # Create session
+    session = research_state.create_session(
+        question=body.question,
+        template=body.template,
+    )
+
+    # Start research in background thread
+    background_tasks.add_task(
+        run_research_background,
+        session,
+        body.recursion_limit,
+    )
+
+    return {
+        "research_id": session.id,
+        "status": "started",
+        "stream_url": f"/research/{session.id}/stream",
+    }
+
+
+@router.get("/research/{research_id}/status")
+async def get_research_status(research_id: str):
+    """Get the current status of a research session."""
+    session = research_state.get_session(research_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Research session not found")
+    return session.to_dict()
+
+
+@router.get("/research/{research_id}/stream")
+async def stream_research_events(research_id: str):
+    """Stream research events via Server-Sent Events."""
+    session = research_state.get_session(research_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Research session not found")
+
+    async def event_generator():
+        """Generate SSE events from the session queue."""
+        # Send initial status
+        yield format_sse_event("status", session.to_dict())
+
+        while True:
+            try:
+                # Wait for events with timeout
+                event = await asyncio.wait_for(session.event_queue.get(), timeout=30.0)
+
+                if event is None:  # End signal
+                    yield format_sse_event("complete", session.to_dict())
+                    break
+
+                event_type = event.get("type", "update")
+                event_data = event.get("data", {})
+                yield format_sse_event(event_type, event_data)
+
+            except asyncio.TimeoutError:
+                # Send keepalive
+                yield format_sse_event(
+                    "keepalive", {"timestamp": datetime.now().isoformat()}
+                )
+
+            except Exception as e:
+                yield format_sse_event("error", {"message": str(e)})
+                break
+
+            # Check if session is done
+            if session.status in (
+                ResearchStatus.COMPLETED,
+                ResearchStatus.FAILED,
+                ResearchStatus.CANCELLED,
+            ):
+                yield format_sse_event("complete", session.to_dict())
+                break
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/research/{research_id}/stop")
+async def stop_research(research_id: str):
+    """Stop a running research session."""
+    session = research_state.get_session(research_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Research session not found")
+
+    if session.status != ResearchStatus.RUNNING:
+        raise HTTPException(status_code=400, detail="Research is not running")
+
+    session.status = ResearchStatus.CANCELLED
+    session.completed_at = datetime.now()
+
+    # Signal end of stream
+    await session.event_queue.put(None)
+
+    return {"status": "cancelled"}
+
+
+@router.get("/research/{research_id}/report")
+async def download_report(research_id: str):
+    """Download the research report as Markdown."""
+    session = research_state.get_session(research_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Research session not found")
+
+    if not session.report_path or not os.path.exists(session.report_path):
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    return FileResponse(
+        session.report_path,
+        media_type="text/markdown",
+        filename=os.path.basename(session.report_path),
+    )
+
+
+@router.get("/templates")
+async def get_templates():
+    """Get list of available templates."""
+    return get_template_info()
+
+
+@router.get("/research/{research_id}", response_class=HTMLResponse)
+async def research_page(request: Request, research_id: str):
+    """Render the research progress page."""
+    session = research_state.get_session(research_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Research session not found")
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        "research.html",
+        {
+            "request": request,
+            "session": session,
+        },
+    )
+
+
+def run_research_background(session: ResearchSession, recursion_limit: int):
+    """Run research in a background thread."""
+    import asyncio
+    from ..tracking import AgentTracker
+    from ..search import HybridSearchTool, SearchStatusDisplay
+    from ..runners import run_research
+
+    # Create a new event loop for this thread
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    try:
+        session.status = ResearchStatus.RUNNING
+        session.started_at = datetime.now()
+        session.recursion_limit = recursion_limit
+
+        # Create callback-enabled tracker
+        tracker = AgentTracker()
+        tracker.iteration_count = 0
+        tracker.recursion_limit = recursion_limit
+
+        # Create callback to push updates to SSE queue
+        def on_update(update_type: str, data: dict):
+            """Callback for research updates."""
+            # Update session state
+            session.iteration_count = tracker.iteration_count
+            session.searches_count = tracker.searches_count
+            session.cache_hits = getattr(tracker, "cache_hits", 0)
+            session.total_input_tokens = tracker.total_input_tokens
+            session.total_output_tokens = tracker.total_output_tokens
+            session.current_status = getattr(tracker, "current_status", "Processing...")
+            session.todos = getattr(tracker, "current_todos", []) or []
+
+            # Push event to queue
+            try:
+                loop.call_soon_threadsafe(
+                    session.event_queue.put_nowait,
+                    {"type": update_type, "data": session.to_dict()},
+                )
+            except Exception:
+                pass  # Queue might be full or closed
+
+        # Attach callback to tracker
+        tracker.on_update = on_update
+
+        # Create search tool with display
+        search_tool = HybridSearchTool(provider="multi-search")
+        search_display = SearchStatusDisplay()
+
+        # Override search display to capture searches
+        original_add = search_display.add_search
+
+        def capture_search(*args, **kwargs):
+            original_add(*args, **kwargs)
+            session.recent_searches = list(search_display.recent_searches)
+            on_update("search", {"searches": session.recent_searches})
+
+        search_display.add_search = capture_search
+
+        # Run research
+        run_research(
+            question=session.question,
+            recursion_limit=recursion_limit,
+            tracker=tracker,
+            search_tool=search_tool,
+            search_display=search_display,
+            template=session.template,
+        )
+
+        # Find the report
+        import glob
+
+        report_files = glob.glob(os.path.join(RESEARCH_FOLDER, "*.md"))
+        if report_files:
+            # Get most recent
+            session.report_path = max(report_files, key=os.path.getmtime)
+
+        session.status = ResearchStatus.COMPLETED
+        session.completed_at = datetime.now()
+
+    except Exception as e:
+        session.status = ResearchStatus.FAILED
+        session.error = str(e)
+        session.completed_at = datetime.now()
+
+    finally:
+        # Signal end of stream
+        try:
+            loop.call_soon_threadsafe(session.event_queue.put_nowait, None)
+        except Exception:
+            pass
+        loop.close()

--- a/ai_researcher/web/sse.py
+++ b/ai_researcher/web/sse.py
@@ -1,0 +1,35 @@
+"""Server-Sent Events utilities."""
+
+import json
+from typing import Any
+
+
+def format_sse_event(event_type: str, data: Any) -> str:
+    """
+    Format data as a Server-Sent Events message.
+
+    Args:
+        event_type: The event type (e.g., "status", "search", "complete")
+        data: Data to serialize as JSON
+
+    Returns:
+        Formatted SSE message string
+    """
+    # Serialize data to JSON
+    if isinstance(data, dict):
+        json_data = json.dumps(data, default=str)
+    else:
+        json_data = json.dumps({"value": data}, default=str)
+
+    # Format as SSE
+    lines = [
+        f"event: {event_type}",
+        f"data: {json_data}",
+        "",  # Empty line to end the event
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def format_keepalive() -> str:
+    """Format a keepalive/heartbeat message."""
+    return ": keepalive\n\n"

--- a/ai_researcher/web/state.py
+++ b/ai_researcher/web/state.py
@@ -1,0 +1,124 @@
+"""Shared state management for research sessions."""
+
+import asyncio
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class ResearchStatus(Enum):
+    """Status of a research session."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class ResearchSession:
+    """Represents a single research session."""
+
+    id: str
+    question: str
+    template: Optional[str] = None
+    status: ResearchStatus = ResearchStatus.PENDING
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    report_path: Optional[str] = None
+    error: Optional[str] = None
+
+    # Progress tracking
+    iteration_count: int = 0
+    recursion_limit: int = 200
+    searches_count: int = 0
+    cache_hits: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    current_status: str = "Waiting..."
+    todos: list = field(default_factory=list)
+    recent_searches: list = field(default_factory=list)
+
+    # Event queue for SSE
+    event_queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+
+    # Background thread
+    _thread: Optional[threading.Thread] = None
+
+    def to_dict(self) -> dict:
+        """Convert session to dictionary for JSON serialization."""
+        elapsed = None
+        if self.started_at:
+            end = self.completed_at or datetime.now()
+            elapsed = (end - self.started_at).total_seconds()
+
+        return {
+            "id": self.id,
+            "question": self.question,
+            "template": self.template,
+            "status": self.status.value,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat()
+            if self.completed_at
+            else None,
+            "elapsed_seconds": elapsed,
+            "report_path": self.report_path,
+            "error": self.error,
+            "iteration_count": self.iteration_count,
+            "recursion_limit": self.recursion_limit,
+            "searches_count": self.searches_count,
+            "cache_hits": self.cache_hits,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "current_status": self.current_status,
+            "todos": self.todos,
+            "recent_searches": self.recent_searches[-5:],  # Last 5 searches
+        }
+
+
+class ResearchStateManager:
+    """Manages all research sessions."""
+
+    def __init__(self):
+        self._sessions: dict[str, ResearchSession] = {}
+        self._lock = threading.Lock()
+
+    def create_session(
+        self, question: str, template: Optional[str] = None
+    ) -> ResearchSession:
+        """Create a new research session."""
+        session_id = str(uuid.uuid4())[:8]
+        session = ResearchSession(
+            id=session_id,
+            question=question,
+            template=template,
+        )
+        with self._lock:
+            self._sessions[session_id] = session
+        return session
+
+    def get_session(self, session_id: str) -> Optional[ResearchSession]:
+        """Get a research session by ID."""
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def list_sessions(self) -> list[ResearchSession]:
+        """List all research sessions."""
+        with self._lock:
+            return list(self._sessions.values())
+
+    def cleanup(self):
+        """Cleanup all sessions on shutdown."""
+        with self._lock:
+            for session in self._sessions.values():
+                if session.status == ResearchStatus.RUNNING:
+                    session.status = ResearchStatus.CANCELLED
+            self._sessions.clear()
+
+
+# Global state instance
+research_state = ResearchStateManager()

--- a/ai_researcher/web/templates/base.html
+++ b/ai_researcher/web/templates/base.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="nl" data-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}AI Research Agent{% endblock %}</title>
+
+    <!-- Pico CSS for minimal, semantic styling -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+
+    <!-- HTMX for reactive updates -->
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
+
+    <style>
+        :root {
+            --primary: #6366f1;
+            --primary-hover: #4f46e5;
+        }
+
+        .container-lg {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+
+        .header h1 {
+            margin-bottom: 0.5rem;
+        }
+
+        .header .subtitle {
+            color: var(--muted-color);
+            font-size: 0.9rem;
+        }
+
+        .card {
+            background: var(--card-background-color);
+            border-radius: var(--border-radius);
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+            border: 1px solid var(--muted-border-color);
+        }
+
+        .card h3 {
+            margin-top: 0;
+            margin-bottom: 1rem;
+        }
+
+        .progress-bar {
+            background: var(--muted-border-color);
+            border-radius: 0.25rem;
+            height: 8px;
+            overflow: hidden;
+        }
+
+        .progress-bar-fill {
+            background: var(--primary);
+            height: 100%;
+            transition: width 0.3s ease;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 1rem;
+        }
+
+        .stat {
+            text-align: center;
+            padding: 0.5rem;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: var(--primary);
+        }
+
+        .stat-label {
+            font-size: 0.8rem;
+            color: var(--muted-color);
+        }
+
+        .todo-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .todo-item {
+            padding: 0.5rem 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            border-bottom: 1px solid var(--muted-border-color);
+        }
+
+        .todo-item:last-child {
+            border-bottom: none;
+        }
+
+        .todo-item.completed {
+            text-decoration: line-through;
+            color: var(--muted-color);
+        }
+
+        .todo-item.in_progress {
+            font-weight: bold;
+        }
+
+        .todo-icon {
+            width: 1.2em;
+        }
+
+        .search-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            font-family: monospace;
+            font-size: 0.85rem;
+        }
+
+        .search-item {
+            padding: 0.25rem 0;
+            color: var(--muted-color);
+        }
+
+        .search-item .query {
+            color: var(--color);
+        }
+
+        .search-item .results {
+            color: var(--primary);
+        }
+
+        .report-preview {
+            background: var(--code-background-color);
+            padding: 1rem;
+            border-radius: var(--border-radius);
+            max-height: 400px;
+            overflow-y: auto;
+            font-family: monospace;
+            font-size: 0.85rem;
+            white-space: pre-wrap;
+        }
+
+        .button-group {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        @media (max-width: 768px) {
+            .container-lg {
+                padding: 1rem;
+            }
+
+            .stats-grid {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+    </style>
+
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    <main class="container-lg">
+        {% block content %}{% endblock %}
+    </main>
+
+    {% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/ai_researcher/web/templates/index.html
+++ b/ai_researcher/web/templates/index.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}AI Research Agent{% endblock %}
+
+{% block content %}
+<div class="header">
+    <h1>🔬 AI Research Agent</h1>
+    <p class="subtitle">Diepgaand onderzoek aangedreven door Claude & DeepAgents</p>
+</div>
+
+<form id="research-form" action="/research/start" method="post">
+    <div class="card">
+        <h3>Onderzoeksvraag</h3>
+        <textarea
+            name="question"
+            id="question"
+            placeholder="Wat wil je onderzoeken? Bijv: Wat zijn de nieuwste ontwikkelingen in quantum computing?"
+            rows="3"
+            required
+        ></textarea>
+    </div>
+
+    <div class="card">
+        <h3>Opties</h3>
+
+        <label for="template">
+            <strong>Rapport Template</strong>
+            <select name="template" id="template">
+                <option value="">Standaard (flexibele structuur)</option>
+                {% for t in templates %}
+                {% if t.name != 'default' %}
+                <option value="{{ t.name }}">{{ t.name|capitalize }} - {{ t.description }}</option>
+                {% endif %}
+                {% endfor %}
+            </select>
+        </label>
+
+        <label for="recursion_limit">
+            <strong>Maximaal aantal iteraties</strong>
+            <input
+                type="number"
+                name="recursion_limit"
+                id="recursion_limit"
+                value="200"
+                min="50"
+                max="500"
+                step="50"
+            >
+            <small>Hoger = diepgaander onderzoek, maar duurt langer (50-500)</small>
+        </label>
+    </div>
+
+    <button type="submit" id="submit-btn">
+        🚀 Start Onderzoek
+    </button>
+</form>
+
+<div id="error-message" class="card hidden" style="border-color: var(--del-color);">
+    <p id="error-text" style="color: var(--del-color);"></p>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+document.getElementById('research-form').addEventListener('submit', async function(e) {
+    e.preventDefault();
+
+    const submitBtn = document.getElementById('submit-btn');
+    const errorDiv = document.getElementById('error-message');
+    const errorText = document.getElementById('error-text');
+
+    // Disable button and show loading state
+    submitBtn.disabled = true;
+    submitBtn.textContent = '⏳ Starten...';
+    submitBtn.setAttribute('aria-busy', 'true');
+    errorDiv.classList.add('hidden');
+
+    try {
+        const formData = new FormData(this);
+        const data = {
+            question: formData.get('question'),
+            template: formData.get('template') || null,
+            recursion_limit: parseInt(formData.get('recursion_limit')) || 200
+        };
+
+        const response = await fetch('/research/start', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data)
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.detail || 'Er is een fout opgetreden');
+        }
+
+        const result = await response.json();
+
+        // Redirect to research page
+        window.location.href = `/research/${result.research_id}`;
+
+    } catch (error) {
+        console.error('Error:', error);
+        errorText.textContent = error.message;
+        errorDiv.classList.remove('hidden');
+
+        // Reset button
+        submitBtn.disabled = false;
+        submitBtn.textContent = '🚀 Start Onderzoek';
+        submitBtn.removeAttribute('aria-busy');
+    }
+});
+</script>
+{% endblock %}

--- a/ai_researcher/web/templates/research.html
+++ b/ai_researcher/web/templates/research.html
@@ -1,0 +1,266 @@
+{% extends "base.html" %}
+
+{% block title %}Onderzoek: {{ session.question[:50] }}...{% endblock %}
+
+{% block content %}
+<div class="header">
+    <h1>🔬 AI Research Agent</h1>
+    <p class="subtitle">{{ session.question }}</p>
+</div>
+
+<div id="research-container"
+     hx-ext="sse"
+     sse-connect="/research/{{ session.id }}/stream"
+     sse-swap="status"
+     hx-swap="none">
+
+    <!-- Status Card -->
+    <div class="card" id="status-card">
+        <h3>📊 Status</h3>
+        <div class="stats-grid">
+            <div class="stat">
+                <div class="stat-value" id="elapsed">--:--</div>
+                <div class="stat-label">Verstreken tijd</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value"><span id="iteration">0</span>/<span id="limit">{{ session.recursion_limit }}</span></div>
+                <div class="stat-label">Iteraties</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value" id="searches">0</div>
+                <div class="stat-label">Zoekopdrachten</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value" id="cost">$0.00</div>
+                <div class="stat-label">Kosten</div>
+            </div>
+        </div>
+
+        <div style="margin-top: 1rem;">
+            <div class="progress-bar">
+                <div class="progress-bar-fill" id="progress-fill" style="width: 0%"></div>
+            </div>
+            <small id="current-status" style="color: var(--muted-color);">🤖 Starten...</small>
+        </div>
+    </div>
+
+    <!-- Search Activity Card -->
+    <div class="card">
+        <h3>🔍 Zoekactiviteit</h3>
+        <ul class="search-list" id="search-list">
+            <li class="search-item">Wachten op eerste zoekopdracht...</li>
+        </ul>
+    </div>
+
+    <!-- Todos Card -->
+    <div class="card">
+        <h3>📋 Taken</h3>
+        <ul class="todo-list" id="todo-list">
+            <li class="todo-item">Wachten op taken...</li>
+        </ul>
+    </div>
+
+    <!-- Completion Card (hidden until done) -->
+    <div class="card hidden" id="completion-card">
+        <h3>✅ Onderzoek voltooid!</h3>
+        <div class="button-group">
+            <a href="/research/{{ session.id }}/report" class="contrast" role="button" id="download-btn">
+                📄 Download Rapport
+            </a>
+            <a href="/" role="button" class="secondary">
+                🔄 Nieuw Onderzoek
+            </a>
+        </div>
+        <div id="report-preview-container" style="margin-top: 1rem;">
+            <details>
+                <summary>Rapport preview</summary>
+                <pre class="report-preview" id="report-preview">Laden...</pre>
+            </details>
+        </div>
+    </div>
+
+    <!-- Error Card (hidden until error) -->
+    <div class="card hidden" id="error-card" style="border-color: var(--del-color);">
+        <h3 style="color: var(--del-color);">❌ Fout opgetreden</h3>
+        <p id="error-message"></p>
+        <a href="/" role="button" class="secondary">Terug naar start</a>
+    </div>
+
+    <!-- Stop Button -->
+    <div id="stop-container">
+        <button class="secondary" id="stop-btn" onclick="stopResearch()">
+            ⏹️ Stop Onderzoek
+        </button>
+    </div>
+
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+const researchId = "{{ session.id }}";
+let startTime = new Date();
+let elapsedInterval;
+
+// Start elapsed time counter
+function updateElapsed() {
+    const now = new Date();
+    const elapsed = Math.floor((now - startTime) / 1000);
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = elapsed % 60;
+    document.getElementById('elapsed').textContent =
+        `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+elapsedInterval = setInterval(updateElapsed, 1000);
+
+// Handle SSE events
+document.body.addEventListener('sse:status', function(e) {
+    const data = JSON.parse(e.detail.data);
+    updateUI(data);
+});
+
+document.body.addEventListener('sse:search', function(e) {
+    const data = JSON.parse(e.detail.data);
+    updateSearches(data.searches || []);
+});
+
+document.body.addEventListener('sse:complete', function(e) {
+    const data = JSON.parse(e.detail.data);
+    handleComplete(data);
+});
+
+document.body.addEventListener('sse:error', function(e) {
+    const data = JSON.parse(e.detail.data);
+    handleError(data.message);
+});
+
+function updateUI(data) {
+    // Update stats
+    document.getElementById('iteration').textContent = data.iteration_count || 0;
+    document.getElementById('limit').textContent = data.recursion_limit || 200;
+    document.getElementById('searches').textContent = data.searches_count || 0;
+
+    // Calculate cost
+    const inputCost = (data.total_input_tokens || 0) * 0.000003;
+    const outputCost = (data.total_output_tokens || 0) * 0.000015;
+    document.getElementById('cost').textContent = `$${(inputCost + outputCost).toFixed(2)}`;
+
+    // Update progress bar
+    const progress = ((data.iteration_count || 0) / (data.recursion_limit || 200)) * 100;
+    document.getElementById('progress-fill').style.width = `${Math.min(progress, 100)}%`;
+
+    // Update status
+    document.getElementById('current-status').textContent = `🤖 ${data.current_status || 'Processing...'}`;
+
+    // Update todos
+    if (data.todos && data.todos.length > 0) {
+        updateTodos(data.todos);
+    }
+
+    // Update searches
+    if (data.recent_searches && data.recent_searches.length > 0) {
+        updateSearches(data.recent_searches);
+    }
+
+    // Check for completion
+    if (data.status === 'completed') {
+        handleComplete(data);
+    } else if (data.status === 'failed') {
+        handleError(data.error || 'Onbekende fout');
+    }
+}
+
+function updateTodos(todos) {
+    const list = document.getElementById('todo-list');
+    list.innerHTML = todos.map(todo => {
+        let icon = '○';
+        let className = 'pending';
+        if (todo.status === 'completed') {
+            icon = '✓';
+            className = 'completed';
+        } else if (todo.status === 'in_progress') {
+            icon = '▶';
+            className = 'in_progress';
+        }
+        return `<li class="todo-item ${className}">
+            <span class="todo-icon">${icon}</span>
+            ${todo.content || todo.activeForm || ''}
+        </li>`;
+    }).join('');
+}
+
+function updateSearches(searches) {
+    const list = document.getElementById('search-list');
+    if (searches.length === 0) return;
+
+    list.innerHTML = searches.slice(-5).reverse().map(s => {
+        const cached = s.cached ? ' (cache)' : '';
+        return `<li class="search-item">
+            #${s.num || '?'} <span class="query">${s.query || ''}</span>
+            → <span class="results">${s.results_count || 0} resultaten${cached}</span>
+        </li>`;
+    }).join('');
+}
+
+function handleComplete(data) {
+    clearInterval(elapsedInterval);
+
+    // Update final elapsed time
+    if (data.elapsed_seconds) {
+        const minutes = Math.floor(data.elapsed_seconds / 60);
+        const seconds = Math.floor(data.elapsed_seconds % 60);
+        document.getElementById('elapsed').textContent =
+            `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    }
+
+    // Show completion card
+    document.getElementById('completion-card').classList.remove('hidden');
+    document.getElementById('stop-container').classList.add('hidden');
+    document.getElementById('current-status').textContent = '✅ Voltooid!';
+
+    // Load report preview if available
+    if (data.report_path) {
+        fetch(`/research/${researchId}/report`)
+            .then(r => r.text())
+            .then(text => {
+                document.getElementById('report-preview').textContent = text.slice(0, 2000) + '...';
+            })
+            .catch(e => console.error('Could not load report preview:', e));
+    }
+}
+
+function handleError(message) {
+    clearInterval(elapsedInterval);
+
+    document.getElementById('error-card').classList.remove('hidden');
+    document.getElementById('error-message').textContent = message;
+    document.getElementById('stop-container').classList.add('hidden');
+    document.getElementById('current-status').textContent = '❌ Fout';
+}
+
+async function stopResearch() {
+    const btn = document.getElementById('stop-btn');
+    btn.disabled = true;
+    btn.textContent = '⏳ Stoppen...';
+
+    try {
+        const response = await fetch(`/research/${researchId}/stop`, {
+            method: 'POST'
+        });
+
+        if (!response.ok) {
+            const error = await response.json();
+            console.error('Stop error:', error);
+        }
+
+        // Reload page to show final state
+        window.location.reload();
+
+    } catch (error) {
+        console.error('Error stopping research:', error);
+        btn.disabled = false;
+        btn.textContent = '⏹️ Stop Onderzoek';
+    }
+}
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ tavily-python
 multi-search-api
 python-dotenv
 rich
+pyyaml
+fastapi
+uvicorn[standard]
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 deepagents
 tavily-python
-multi-search-api
+multi-search-api>=0.1.10
 python-dotenv
 rich
 pyyaml

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,252 @@
+"""
+Unit tests for the templates module.
+
+Tests template loading, validation, and prompt generation.
+"""
+
+import pytest
+import os
+from pathlib import Path
+
+
+class TestTemplateLoader:
+    """Tests for template loading functionality."""
+
+    def test_list_templates_returns_list(self):
+        """Test that list_templates returns a non-empty list."""
+        from ai_researcher.templates import list_templates
+
+        templates = list_templates()
+        assert isinstance(templates, list)
+        assert len(templates) > 0
+
+    def test_list_templates_contains_default(self):
+        """Test that default template is available."""
+        from ai_researcher.templates import list_templates
+
+        templates = list_templates()
+        assert "default" in templates
+
+    def test_list_templates_contains_swot(self):
+        """Test that swot template is available."""
+        from ai_researcher.templates import list_templates
+
+        templates = list_templates()
+        assert "swot" in templates
+
+    def test_list_templates_contains_comparison(self):
+        """Test that comparison template is available."""
+        from ai_researcher.templates import list_templates
+
+        templates = list_templates()
+        assert "comparison" in templates
+
+    def test_list_templates_contains_market(self):
+        """Test that market template is available."""
+        from ai_researcher.templates import list_templates
+
+        templates = list_templates()
+        assert "market" in templates
+
+
+class TestLoadTemplate:
+    """Tests for load_template function."""
+
+    def test_load_default_template(self):
+        """Test loading the default template."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("default")
+        assert template is not None
+        assert template.get("name") == "default"
+
+    def test_load_swot_template(self):
+        """Test loading the swot template."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("swot")
+        assert template is not None
+        assert template.get("name") == "swot"
+        assert "sections" in template
+        assert len(template["sections"]) > 0
+
+    def test_load_comparison_template(self):
+        """Test loading the comparison template."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("comparison")
+        assert template is not None
+        assert template.get("name") == "comparison"
+        assert "sections" in template
+
+    def test_load_market_template(self):
+        """Test loading the market template."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("market")
+        assert template is not None
+        assert template.get("name") == "market"
+        assert "sections" in template
+
+    def test_load_nonexistent_template_raises_error(self):
+        """Test that loading a non-existent template raises TemplateNotFoundError."""
+        from ai_researcher.templates import load_template, TemplateNotFoundError
+
+        with pytest.raises(TemplateNotFoundError):
+            load_template("nonexistent_template_xyz")
+
+    def test_template_has_description(self):
+        """Test that templates have descriptions."""
+        from ai_researcher.templates import load_template
+
+        for name in ["swot", "comparison", "market"]:
+            template = load_template(name)
+            assert "description" in template
+            assert len(template["description"]) > 0
+
+
+class TestTemplateInfo:
+    """Tests for get_template_info function."""
+
+    def test_get_template_info_returns_list(self):
+        """Test that get_template_info returns a list of dicts."""
+        from ai_researcher.templates.loader import get_template_info
+
+        info = get_template_info()
+        assert isinstance(info, list)
+        assert len(info) > 0
+
+    def test_template_info_has_name_and_description(self):
+        """Test that each template info has name and description."""
+        from ai_researcher.templates.loader import get_template_info
+
+        info = get_template_info()
+        for t in info:
+            assert "name" in t
+            assert "description" in t
+
+
+class TestGetTemplatePrompt:
+    """Tests for get_template_prompt function."""
+
+    def test_default_template_returns_empty_prompt(self):
+        """Test that default template returns empty prompt (no sections)."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("default")
+        prompt = get_template_prompt(template)
+        # Default template has no mandatory sections
+        assert prompt == ""
+
+    def test_swot_template_generates_sections(self):
+        """Test that SWOT template generates section prompts."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("swot")
+        prompt = get_template_prompt(template)
+
+        # Should contain SWOT sections
+        assert "Strength" in prompt or "Sterktes" in prompt
+        assert "Weakness" in prompt or "Zwaktes" in prompt
+        assert "Opportunit" in prompt or "Kansen" in prompt
+        assert "Threat" in prompt or "Bedreigingen" in prompt
+
+    def test_template_prompt_english(self):
+        """Test template prompt in English."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("swot")
+        prompt = get_template_prompt(template, language="en")
+
+        assert "MANDATORY REPORT STRUCTURE" in prompt
+        assert "Section" in prompt or "Focus" in prompt
+
+    def test_template_prompt_dutch(self):
+        """Test template prompt in Dutch."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("swot")
+        prompt = get_template_prompt(template, language="nl")
+
+        assert "VERPLICHTE RAPPORT STRUCTUUR" in prompt
+
+    def test_comparison_template_generates_sections(self):
+        """Test that comparison template generates correct sections."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("comparison")
+        prompt = get_template_prompt(template)
+
+        # Should contain comparison-related sections
+        assert "Comparison" in prompt or "Vergelijk" in prompt or "Overview" in prompt
+
+    def test_market_template_generates_sections(self):
+        """Test that market template generates correct sections."""
+        from ai_researcher.templates import load_template, get_template_prompt
+
+        template = load_template("market")
+        prompt = get_template_prompt(template)
+
+        # Should contain market analysis sections
+        assert "Market" in prompt or "Markt" in prompt
+
+
+class TestTemplateStructure:
+    """Tests for template YAML structure."""
+
+    def test_swot_has_five_sections(self):
+        """Test that SWOT template has 5 sections."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("swot")
+        sections = template.get("sections", [])
+        assert len(sections) == 5
+
+    def test_comparison_has_five_sections(self):
+        """Test that comparison template has 5 sections."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("comparison")
+        sections = template.get("sections", [])
+        assert len(sections) == 5
+
+    def test_market_has_six_sections(self):
+        """Test that market template has 6 sections."""
+        from ai_researcher.templates import load_template
+
+        template = load_template("market")
+        sections = template.get("sections", [])
+        assert len(sections) == 6
+
+    def test_sections_have_title_and_prompt(self):
+        """Test that template sections have title and prompt fields."""
+        from ai_researcher.templates import load_template
+
+        for name in ["swot", "comparison", "market"]:
+            template = load_template(name)
+            for section in template.get("sections", []):
+                assert "title" in section
+                assert "prompt" in section
+
+
+class TestGetDefaultTemplate:
+    """Tests for get_default_template function."""
+
+    def test_get_default_template_returns_dict(self):
+        """Test that get_default_template returns a dictionary."""
+        from ai_researcher.templates.loader import get_default_template
+
+        template = get_default_template()
+        assert isinstance(template, dict)
+        assert "name" in template
+
+    def test_get_default_template_name_is_default(self):
+        """Test that get_default_template returns 'default' template."""
+        from ai_researcher.templates.loader import get_default_template
+
+        template = get_default_template()
+        assert template.get("name") == "default"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

This PR adds two major features to the AI Research Agent:

### 1. Custom Research Templates
- YAML-based template system for defining report structure
- Built-in templates: **default**, **swot**, **comparison**, **market**
- CLI flags: `--template`, `--list-templates`
- Templates inject mandatory sections into the research prompt

### 2. Web Interface
- FastAPI-based web server with HTMX frontend
- Real-time progress updates via Server-Sent Events (SSE)
- CLI flags: `--web`, `--port`
- Responsive UI using Pico CSS

## Usage Examples

```bash
# List available templates
python research.py --list-templates

# Run research with SWOT template
python research.py -d -t swot "Analyse de kansen voor AI in de zorg"

# Start web interface
python research.py --web
python research.py --web --port 3000
```

## Changes

| File | Description |
|------|-------------|
| `ai_researcher/templates/` | New template module with YAML files |
| `ai_researcher/web/` | New web module with FastAPI app |
| `ai_researcher/cli.py` | Added template and web CLI flags |
| `ai_researcher/runners/deep.py` | Template injection support |
| `tests/test_templates.py` | Unit tests for templates |
| `requirements.txt` | Added fastapi, uvicorn, jinja2, pyyaml |

## Test plan

- [x] All 96 unit tests pass
- [x] `--list-templates` shows available templates
- [x] `--help` shows new flags
- [ ] Manual test: Run deep research with SWOT template
- [ ] Manual test: Start web server and run research via browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)